### PR TITLE
Rewrite mistyped 'Install' to 'install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/Wikimedia-ID/anak-pulau.git && cd anak-pulau
 
 Install dependency
 ```sh
-gem install bundler && bundle Install
+gem install bundler && bundle install
 ```
 
 ## Penggunaan


### PR DESCRIPTION
Followed readme.md,
Run: gem install bundler && bundle Install,
Get this error message:
``Could not find command "Install"``